### PR TITLE
Update _config.yml 共輕聲符號自動替換的特性禁--起來

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -140,6 +140,8 @@ kramdown:
     block:
       line_numbers: true
       start_line: 1
+  typographic_symbols:
+    ndash: "--"
 
 collections:
   tabs:


### PR DESCRIPTION
kramdown 是 jekyll 的 Markdown 處理 ia̋n-jín，預設就會共 `--` 替換做 `–`(en dash)，只要佇 config 共這个特性禁起來就好勢矣，毋免人工一个一个加倒反斜線啦